### PR TITLE
Dev run metadata

### DIFF
--- a/autoprot/analysis/analysis.py
+++ b/autoprot/analysis/analysis.py
@@ -32,7 +32,6 @@ def run_analysis(
     metadata: pd.DataFrame,
     output_dir: str,
     config: dict,
-    json_out: str,
     formula: str,
 ) -> dict:
     """
@@ -54,7 +53,6 @@ def run_analysis(
             - "LFC_threshold" (float): Suggested log fold change threshold for classification and plotting.
             - "FDR_threshold" (float): Suggested p-value threshold for volcano plot annotation.
             - "LFC_plot_p_or_FDRp" (str): Column to use for y-axis in volcano plot.
-        json_out (str): Path to JSON file where version metadata will be recorded.
         formula (str): the formula passted to the DE calculation. May need to be different for full dataset and subsets.
 
     Returns:

--- a/autoprot/processing/data_processing.py
+++ b/autoprot/processing/data_processing.py
@@ -182,9 +182,10 @@ def clean_data(
     Raises:
         ValueError: If metadata is missing or incomplete when required.
     """
-    if "metadata" in file_path:
+    fname = os.path.basename(file_path)
+    if "metadata" in fname:
         df = clean_meta(df=df, json_out=json_out)
-    if "protein" in file_path:
+    if "protein" in fname:
         if metadata is None:
             raise ValueError("Error: Metadata is required but not provided.")
         # Check if the required column is in metadata
@@ -241,7 +242,8 @@ def process_data(file_path, metadata=None, json_out=None, outPath=None, config=N
         df_renamed = normalise_column_names(
             df=df_in, file_path=file_path, outPath=outPath, config=config
         )
-    if "metadata" in file_path:
+    fname = os.path.basename(file_path)
+    if "metadata" in fname:
         ### clean metadata
         df = clean_data(
             df=df_renamed, file_path=file_path, config=config, json_out=json_out
@@ -249,7 +251,7 @@ def process_data(file_path, metadata=None, json_out=None, outPath=None, config=N
         ### run function to validate metadata
         validate_metadata(df)
 
-    if "protein" in file_path:
+    if "protein" in fname:
         df = clean_data(
             df=df_renamed,
             file_path=file_path,

--- a/autoprot/utils/data_io.py
+++ b/autoprot/utils/data_io.py
@@ -61,13 +61,6 @@ def make_outdir(out_path, make_subdirs=True):
     Side effects:
         Creates directories on the file system. Prints status messages.
     """
-    ### some previous outputs are brought into the report unintentionally
-    ### remove output dir if it exists
-    if os.path.exists(out_path):
-        
-        import shutil
-        shutil.rmtree(out_path) # remove directory and all its contents
-
     if not os.path.exists(out_path):
 
         try:

--- a/autoprot/utils/data_utils.py
+++ b/autoprot/utils/data_utils.py
@@ -72,7 +72,7 @@ def normalise_column_names(df, file_path=None, outPath = None, config=None):
     df.columns = df.columns.astype(str) # ensure all columns are strings
 
     # If 'protein' is in the file path, set a column containing 'gene' as the index
-    if "protein" in file_path:
+    if "protein" in os.path.basename(file_path):
 
         genes_columns = [col for col in df.columns if "gene" in col.lower()]
         
@@ -414,29 +414,35 @@ def combine_csv_files(
     print(f"Combined file saved at: {output_filename}")
 
 
-def tidy_up_files(outPath):
+def tidy_up_files(outPath) -> list:
     """
     Remove temporary files created during processing.
 
     Specifically removes:
     - 'prots_name_mapping.csv' from the 'data' directory.
+
+    Returns:
+        List of relative paths (relative to outPath) of files that were deleted.
     """
     files_to_remove = [
         glob.glob(os.path.join(outPath, "full_dataset/data/*/limma_output.csv")),
         glob.glob(os.path.join(outPath, "full_dataset/data/*/prots.csv")),
         glob.glob(os.path.join(outPath, "full_dataset/data/*/top_20_by_LFC.csv")),
     ]
-    
+
     # glob returns a list of files so files_to_remove is currently a list of lists
     # flatten the list of lists
     flattened_files_to_remove = []
     for sublist in files_to_remove: # loop through list of lists
         for file in sublist: # take each file
             flattened_files_to_remove.append(file)
-        
-    # remove each file if it exists
+
+    # remove each file if it exists and track what was deleted
+    deleted = []
     for file in flattened_files_to_remove:
         if os.path.exists(file):
             os.remove(file)
+            deleted.append(os.path.relpath(file, outPath))
 
     print("Temporary files removed.")
+    return deleted

--- a/autoprot/utils/data_utils.py
+++ b/autoprot/utils/data_utils.py
@@ -128,11 +128,14 @@ def normalise_column_names(df, file_path=None, outPath = None, config=None):
         # this is useful for debugging and for tracking proteins through the analysis
         # at this point in the pipeline, the old names are in the column with genes in the name (this will soon be removed)
         # and the new names are the index. so it is a good time to save
-        (df.loc[ df.index != df[genes_columns[0]], ]
-         .rename(columns={'pg.genes': 'pg.genes_original'})
-         .to_csv(os.path.join(outPath, "data/prots_name_mapping.csv"),
-                                                           index = True)
-        )
+
+        # only required if there is a genes columns
+        if genes_columns:
+            (df.loc[ df.index != df[genes_columns[0]], ]
+            .rename(columns={'pg.genes': 'pg.genes_original'})
+            .to_csv(os.path.join(outPath, "data/prots_name_mapping.csv"),
+                                                            index = True)
+            )
 
         ### For phosphoproteomic data, there are abundances for phosphorylated proteins
         ### Each protein can be present multiple times - once per phosphorylation state
@@ -330,6 +333,7 @@ def combine_plots(search_path, search_term, output_dir):
     combined_image = combined_image.convert("P", palette=Image.ADAPTIVE)
 
     # Save the combined image
+    os.makedirs(os.path.join(output_dir, "plots"), exist_ok=True)
     combined_image_path = os.path.join(output_dir, f"plots/combined_{search_term}_plot.png")
     combined_image.save(combined_image_path, optimize = True)
     print(f"Combined image saved to {combined_image_path}")

--- a/autoprot/utils/metadata_recording.py
+++ b/autoprot/utils/metadata_recording.py
@@ -1,0 +1,52 @@
+import hashlib
+import json
+import subprocess
+from datetime import datetime
+
+def file_hash(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+def get_git_info(diff_file=None):
+    try:
+        commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
+        dirty = subprocess.call(['git', 'diff-index', '--quiet', 'HEAD', '--']) != 0
+        if dirty and diff_file:
+            diff = subprocess.check_output(['git', 'diff']).decode()
+            with open(diff_file, 'w') as f:
+                f.write(diff)
+        return {'commit': commit, 'dirty': dirty, 'diff_file': diff_file if dirty else None}
+    except Exception:
+        return {'commit': None, 'dirty': None, 'diff_file': None}
+
+def get_conda_info():
+    """Capture Conda environment details and package list."""
+    try:
+        env_info = subprocess.check_output(['conda', 'info', '--show']).decode()
+        packages = subprocess.check_output(['conda', 'list']).decode()
+        return {'conda_info': env_info, 'conda_list': packages}
+    except Exception:
+        return {'conda_info': None, 'conda_list': None}
+
+def log_run_metadata(input_files, args, run_metadata_file='run_metadata.json'):
+    start_time = datetime.utcnow().isoformat()
+    run_metadata = {
+        'start_time': start_time,
+        'input_files': {f: file_hash(f) for f in input_files},
+        'args': args,
+        'git': get_git_info(diff_file='run_diff.patch'),
+        'conda': get_conda_info()
+    }
+
+    with open(run_metadata_file, 'w') as f:
+        json.dump(run_metadata, f, indent=2)
+
+    return run_metadata_file, run_metadata
+
+def finalise_run_metadata(run_metadata_file, run_metadata):
+    run_metadata['end_time'] = datetime.utcnow().isoformat()
+    with open(run_metadata_file, 'w') as f:
+        json.dump(run_metadata, f, indent=2)

--- a/autoprot/utils/metadata_recording.py
+++ b/autoprot/utils/metadata_recording.py
@@ -58,7 +58,7 @@ def get_git_info(diff_file: Optional[str] = None) -> dict:
                 f.write(diff)
         try:
             tag = subprocess.check_output(
-                ['git', 'describe', '--tags', '--always'],
+                ['git', 'describe', '--tags' ],
                 stderr=subprocess.DEVNULL
             ).decode().strip()
         except Exception:

--- a/autoprot/utils/metadata_recording.py
+++ b/autoprot/utils/metadata_recording.py
@@ -6,6 +6,8 @@ import subprocess
 from datetime import datetime, timezone
 from typing import Optional
 
+import yaml
+
 try:
     import psutil
     _PSUTIL_AVAILABLE = True
@@ -70,6 +72,7 @@ def get_git_info(diff_file: Optional[str] = None) -> dict:
     except Exception:
         return {'commit': None, 'tag': None, 'dirty': None, 'diff_file': None}
 
+
 def get_conda_env(env_name: Optional[str] = None) -> Optional[str]:
     """Return the raw output of `conda list` for a given environment.
 
@@ -94,74 +97,115 @@ def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _write_yaml(run_meta: dict, run_metadata_file: str) -> None:
+    """Serialise run_meta to YAML and write to disk, preserving key order."""
+    with open(run_metadata_file, 'w') as f:
+        yaml.dump(run_meta, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+
 def log_run_metadata(
     input_files: list,
     args: list,
     config: dict,
-    out_path: str,
-    run_metadata_file: str = 'run_metadata.json',
+    run_metadata_file: str = 'run_metadata.yaml',
+    repo_root: Optional[str] = None,
 ) -> tuple:
     """Initialise and write the run metadata file at pipeline start.
 
     Collects input file hashes, command-line arguments, config contents,
     git state, conda package lists, and platform info, then writes them
-    to a JSON file. A `steps` list is included for subsequent step-level
-    timestamps (see `record_step_complete`).
-
+    to a YAML file under <meta_dir>/run_metadata.yaml. Conda environment
+    dumps are written to <meta_dir>/conda_envs/<env_name>.txt (one file
+    per environment) and referenced by name only in the main metadata.
     If the git repo is dirty, a diff patch is written to
-    `<out_path>/run_diff.patch` and referenced in the metadata.
+    <meta_dir>/run_diff.patch and referenced in the metadata.
 
     Args:
         input_files:       List of input file paths to hash.
         args:              Command-line arguments (typically sys.argv).
         config:            Full parsed config dictionary for this run.
-        out_path:          Path to the pipeline output directory.
-        run_metadata_file: Path to write the JSON metadata file to.
+        run_metadata_file: Path to write the YAML metadata file to.
+        repo_root:         Repository root used to compute relative paths for
+                           input_files. If None, absolute paths are stored.
 
     Returns:
         Tuple of (run_metadata_file, run_meta) where run_meta is the
         dict that was serialised — pass both to `record_step_complete`
         and `finalise_run_metadata`.
     """
-    diff_file = os.path.join(out_path, 'run_diff.patch')
+    meta_dir = os.path.dirname(os.path.abspath(run_metadata_file))
+    os.makedirs(meta_dir, exist_ok=True)
+
+    # Write git diff inside the run_metadata dir
+    diff_file = os.path.join(meta_dir, 'run_diff.patch')
     git_info = get_git_info(diff_file=diff_file)
-    
-    # Store diff_file relative to out_path for portability
     if git_info.get('diff_file'):
-        git_info['diff_file'] = os.path.relpath(git_info['diff_file'], out_path)
+        git_info['diff_file'] = os.path.relpath(git_info['diff_file'], meta_dir)
+
+    # Write conda env dumps to separate files; record names only in main metadata
+    conda_env_names = []
+    conda_envs = {
+        'auto-proteomics': get_conda_env(),
+        'r-limma-env': get_conda_env('r-limma-env'),
+    }
+    if any(v is not None for v in conda_envs.values()):
+        conda_envs_dir = os.path.join(meta_dir, 'conda_envs')
+        os.makedirs(conda_envs_dir, exist_ok=True)
+        for env_name, env_text in conda_envs.items():
+            if env_text is not None:
+                conda_env_names.append(env_name)
+                with open(os.path.join(conda_envs_dir, f'{env_name}.txt'), 'w') as f:
+                    f.write(env_text)
+
+    # Use relative input file paths (relative to repo_root when provided)
+    if repo_root:
+        input_files_rel = {
+            os.path.relpath(f, repo_root).replace('\\', '/'): file_hash(f)
+            for f in input_files
+        }
+    else:
+        input_files_rel = {f: file_hash(f) for f in input_files}
 
     run_meta = {
-        'start_time': _utcnow(),
-        'input_files': {f: file_hash(f) for f in input_files},
-        'args': args,
-        'config': config,
-        'out_path': out_path,
-        'git': git_info,
-        'conda': {
-            'auto-proteomics': get_conda_env(),
-            'r-limma-env': get_conda_env('r-limma-env'),
+        'run': {
+            'exit_status': None,
+            'start_time': _utcnow(),
+            'end_time': None,
+            'duration_s': None,
+            'args': list(args),
         },
-        'platform':  platform.platform(),
         'steps': [],
+        'config': config,
+        'provenance': {
+            'platform': platform.platform(),
+            'git': git_info,
+            'conda_env_names': conda_env_names,
+            'input_files': input_files_rel,
+        },
     }
 
-    with open(run_metadata_file, 'w') as f:
-        json.dump(run_meta, f, indent=2)
-
+    _write_yaml(run_meta, run_metadata_file)
     return run_metadata_file, run_meta
 
 
 def load_run_metadata(run_metadata_file: str) -> tuple:
-    """Load an existing run_metadata.json for resume.
+    """Load an existing run metadata file for resume.
+
+    Supports both YAML (.yaml/.yml) and legacy JSON (.json) formats,
+    selected automatically by file extension.
 
     Args:
-        run_metadata_file: Path to the JSON file.
+        run_metadata_file: Path to the metadata file.
 
     Returns:
         Tuple of (run_meta dict, completed_steps set of step name strings).
     """
     with open(run_metadata_file) as f:
-        run_meta = json.load(f)
+        ext = os.path.splitext(run_metadata_file)[1].lower()
+        if ext in ('.yaml', '.yml'):
+            run_meta = yaml.safe_load(f)
+        else:
+            run_meta = json.load(f)
     completed_steps = {s['step'] for s in run_meta.get('steps', []) if s['status'] == 'success'}
     return run_meta, completed_steps
 
@@ -176,7 +220,7 @@ def record_step_complete(
     """Append a timestamped step record to the run metadata and flush to disk.
 
     Call this immediately after each major pipeline step completes so that
-    the JSON file always reflects the latest progress, even if the run is
+    the YAML file always reflects the latest progress, even if the run is
     interrupted later.
 
     Args:
@@ -185,15 +229,14 @@ def record_step_complete(
         status:            Outcome of the step, typically 'success' or 'error'.
         run_meta:          The in-memory metadata dict returned by
                            `log_run_metadata`.
-        run_metadata_file: Path to the JSON file to update.
+        run_metadata_file: Path to the YAML file to update.
         details:           Optional dict of extra metadata to include in the step entry.
     """
     entry = {'step': step_name, 'status': status, 'timestamp': _utcnow()}
     if details:
         entry['details'] = details
     run_meta['steps'].append(entry)
-    with open(run_metadata_file, 'w') as f:
-        json.dump(run_meta, f, indent=2)
+    _write_yaml(run_meta, run_metadata_file)
 
 
 def finalise_run_metadata(
@@ -204,31 +247,40 @@ def finalise_run_metadata(
 ) -> None:
     """Write final fields to the run metadata file at pipeline end.
 
-    Adds end timestamp, exit status, optional error message, and resource
-    usage (peak RSS memory and total CPU time) if psutil is available.
+    Adds end timestamp, duration, exit status, optional error message, and
+    resource usage (peak RSS memory and total CPU time) if psutil is available.
 
     Args:
-        run_metadata_file: Path to the JSON metadata file to update.
+        run_metadata_file: Path to the YAML metadata file to update.
         run_meta:          The in-memory metadata dict returned by
                            `log_run_metadata`.
         exit_status:       'success' or 'error'.
         error:             Exception message string, included only when
                            exit_status is 'error'.
     """
-    run_meta['end_time'] = _utcnow()
-    run_meta['exit_status'] = exit_status
+    end_time = _utcnow()
+    run_block = run_meta.setdefault('run', {})
+    run_block['end_time'] = end_time
+    run_block['exit_status'] = exit_status
+
+    try:
+        start = datetime.fromisoformat(run_block['start_time'])
+        end = datetime.fromisoformat(end_time)
+        run_block['duration_s'] = round((end - start).total_seconds(), 3)
+    except Exception:
+        run_block['duration_s'] = None
+
     if error is not None:
-        run_meta['error'] = error
+        run_block['error'] = error
 
     if _PSUTIL_AVAILABLE:
         try:
             proc = psutil.Process()
-            run_meta['resources'] = {
+            run_block['resources'] = {
                 'peak_memory_mb': proc.memory_info().rss / 1e6,
                 'cpu_time_s': sum(proc.cpu_times()[:2]),
             }
         except Exception:
             pass
 
-    with open(run_metadata_file, 'w') as f:
-        json.dump(run_meta, f, indent=2)
+    _write_yaml(run_meta, run_metadata_file)

--- a/autoprot/utils/metadata_recording.py
+++ b/autoprot/utils/metadata_recording.py
@@ -1,16 +1,52 @@
 import hashlib
 import json
+import os
+import platform
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Optional
 
-def file_hash(path):
+try:
+    import psutil
+    _PSUTIL_AVAILABLE = True
+except ImportError:
+    _PSUTIL_AVAILABLE = False
+
+
+def file_hash(path: str) -> str:
+    """Compute the SHA-256 hex digest of a file.
+
+    Args:
+        path: Path to the file to hash.
+
+    Returns:
+        Lowercase hex string of the SHA-256 digest.
+    """
     h = hashlib.sha256()
     with open(path, 'rb') as f:
         for chunk in iter(lambda: f.read(8192), b''):
             h.update(chunk)
     return h.hexdigest()
 
-def get_git_info(diff_file=None):
+
+def get_git_info(diff_file: Optional[str] = None) -> dict:
+    """Capture git repository state at the time of the run.
+
+    If the working tree is dirty and `diff_file` is provided, the full
+    unstaged diff is written to that path so the exact code state can be
+    reproduced later.
+
+    Args:
+        diff_file: Path to write the diff patch to when the repo is dirty.
+                   If None, no patch is written.
+
+    Returns:
+        Dict with keys:
+            commit    – full SHA of HEAD (str or None on failure)
+            tag       – nearest tag from `git describe --tags --always` (str or None)
+            dirty     – True if the working tree has uncommitted changes (bool or None)
+            diff_file – path to the written patch file, or None if not applicable
+    """
     try:
         commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode().strip()
         dirty = subprocess.call(['git', 'diff-index', '--quiet', 'HEAD', '--']) != 0
@@ -18,35 +54,181 @@ def get_git_info(diff_file=None):
             diff = subprocess.check_output(['git', 'diff']).decode()
             with open(diff_file, 'w') as f:
                 f.write(diff)
-        return {'commit': commit, 'dirty': dirty, 'diff_file': diff_file if dirty else None}
+        try:
+            tag = subprocess.check_output(
+                ['git', 'describe', '--tags', '--always'],
+                stderr=subprocess.DEVNULL
+            ).decode().strip()
+        except Exception:
+            tag = None
+        return {
+            'commit': commit,
+            'tag': tag,
+            'dirty': dirty,
+            'diff_file': diff_file if dirty else None,
+        }
     except Exception:
-        return {'commit': None, 'dirty': None, 'diff_file': None}
+        return {'commit': None, 'tag': None, 'dirty': None, 'diff_file': None}
 
-def get_conda_info():
-    """Capture Conda environment details and package list."""
+def get_conda_env(env_name: Optional[str] = None) -> Optional[str]:
+    """Return the raw output of `conda list` for a given environment.
+
+    Args:
+        env_name: Name of the conda environment to query. If None, the
+                  currently active environment is used. For main.py to be running, auto-prot will be active so conda env details will be recorded.
+
+    Returns:
+        Raw text output of `conda list`, or None if the command fails.
+    """
     try:
-        env_info = subprocess.check_output(['conda', 'info', '--show']).decode()
-        packages = subprocess.check_output(['conda', 'list']).decode()
-        return {'conda_info': env_info, 'conda_list': packages}
+        cmd = ['conda', 'list']
+        if env_name:
+            cmd += ['-n', env_name]
+        return subprocess.check_output(cmd).decode()
     except Exception:
-        return {'conda_info': None, 'conda_list': None}
+        return None
 
-def log_run_metadata(input_files, args, run_metadata_file='run_metadata.json'):
-    start_time = datetime.utcnow().isoformat()
-    run_metadata = {
-        'start_time': start_time,
+
+def _utcnow() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def log_run_metadata(
+    input_files: list,
+    args: list,
+    config: dict,
+    out_path: str,
+    run_metadata_file: str = 'run_metadata.json',
+) -> tuple:
+    """Initialise and write the run metadata file at pipeline start.
+
+    Collects input file hashes, command-line arguments, config contents,
+    git state, conda package lists, and platform info, then writes them
+    to a JSON file. A `steps` list is included for subsequent step-level
+    timestamps (see `record_step_complete`).
+
+    If the git repo is dirty, a diff patch is written to
+    `<out_path>/run_diff.patch` and referenced in the metadata.
+
+    Args:
+        input_files:       List of input file paths to hash.
+        args:              Command-line arguments (typically sys.argv).
+        config:            Full parsed config dictionary for this run.
+        out_path:          Path to the pipeline output directory.
+        run_metadata_file: Path to write the JSON metadata file to.
+
+    Returns:
+        Tuple of (run_metadata_file, run_meta) where run_meta is the
+        dict that was serialised — pass both to `record_step_complete`
+        and `finalise_run_metadata`.
+    """
+    diff_file = os.path.join(out_path, 'run_diff.patch')
+    git_info = get_git_info(diff_file=diff_file)
+    
+    # Store diff_file relative to out_path for portability
+    if git_info.get('diff_file'):
+        git_info['diff_file'] = os.path.relpath(git_info['diff_file'], out_path)
+
+    run_meta = {
+        'start_time': _utcnow(),
         'input_files': {f: file_hash(f) for f in input_files},
         'args': args,
-        'git': get_git_info(diff_file='run_diff.patch'),
-        'conda': get_conda_info()
+        'config': config,
+        'out_path': out_path,
+        'git': git_info,
+        'conda': {
+            'auto-proteomics': get_conda_env(),
+            'r-limma-env': get_conda_env('r-limma-env'),
+        },
+        'platform':  platform.platform(),
+        'steps': [],
     }
 
     with open(run_metadata_file, 'w') as f:
-        json.dump(run_metadata, f, indent=2)
+        json.dump(run_meta, f, indent=2)
 
-    return run_metadata_file, run_metadata
+    return run_metadata_file, run_meta
 
-def finalise_run_metadata(run_metadata_file, run_metadata):
-    run_metadata['end_time'] = datetime.utcnow().isoformat()
+
+def load_run_metadata(run_metadata_file: str) -> tuple:
+    """Load an existing run_metadata.json for resume.
+
+    Args:
+        run_metadata_file: Path to the JSON file.
+
+    Returns:
+        Tuple of (run_meta dict, completed_steps set of step name strings).
+    """
+    with open(run_metadata_file) as f:
+        run_meta = json.load(f)
+    completed_steps = {s['step'] for s in run_meta.get('steps', []) if s['status'] == 'success'}
+    return run_meta, completed_steps
+
+
+def record_step_complete(
+    step_name: str,
+    status: str,
+    run_meta: dict,
+    run_metadata_file: str,
+    details: Optional[dict] = None,
+) -> None:
+    """Append a timestamped step record to the run metadata and flush to disk.
+
+    Call this immediately after each major pipeline step completes so that
+    the JSON file always reflects the latest progress, even if the run is
+    interrupted later.
+
+    Args:
+        step_name:         Human-readable name for the completed step
+                           (e.g. 'data_processing', 'subset_Control').
+        status:            Outcome of the step, typically 'success' or 'error'.
+        run_meta:          The in-memory metadata dict returned by
+                           `log_run_metadata`.
+        run_metadata_file: Path to the JSON file to update.
+        details:           Optional dict of extra metadata to include in the step entry.
+    """
+    entry = {'step': step_name, 'status': status, 'timestamp': _utcnow()}
+    if details:
+        entry['details'] = details
+    run_meta['steps'].append(entry)
     with open(run_metadata_file, 'w') as f:
-        json.dump(run_metadata, f, indent=2)
+        json.dump(run_meta, f, indent=2)
+
+
+def finalise_run_metadata(
+    run_metadata_file: str,
+    run_meta: dict,
+    exit_status: str = 'success',
+    error: Optional[str] = None,
+) -> None:
+    """Write final fields to the run metadata file at pipeline end.
+
+    Adds end timestamp, exit status, optional error message, and resource
+    usage (peak RSS memory and total CPU time) if psutil is available.
+
+    Args:
+        run_metadata_file: Path to the JSON metadata file to update.
+        run_meta:          The in-memory metadata dict returned by
+                           `log_run_metadata`.
+        exit_status:       'success' or 'error'.
+        error:             Exception message string, included only when
+                           exit_status is 'error'.
+    """
+    run_meta['end_time'] = _utcnow()
+    run_meta['exit_status'] = exit_status
+    if error is not None:
+        run_meta['error'] = error
+
+    if _PSUTIL_AVAILABLE:
+        try:
+            proc = psutil.Process()
+            run_meta['resources'] = {
+                'peak_memory_mb': proc.memory_info().rss / 1e6,
+                'cpu_time_s': sum(proc.cpu_times()[:2]),
+            }
+        except Exception:
+            pass
+
+    with open(run_metadata_file, 'w') as f:
+        json.dump(run_meta, f, indent=2)

--- a/configs/auto-prot-config.yaml
+++ b/configs/auto-prot-config.yaml
@@ -2,6 +2,8 @@
 # AUTO-PROTEOMICS CONFIG
 # ========================
 # This file controls how the pipeline runs. Update paths and parameters as needed.
+# ---- RUN SETTINGS ----
+resume: false                     # Whether to resume from last checkpoint (true/false)
 
 # ---- DATA SETTINGS ----
 data_type: prot                 # Type of data: "prot" for proteomics (default), "phospho" for phosphoproteomics

--- a/configs/auto-prot-config.yaml
+++ b/configs/auto-prot-config.yaml
@@ -3,7 +3,7 @@
 # ========================
 # This file controls how the pipeline runs. Update paths and parameters as needed.
 # ---- RUN SETTINGS ----
-resume: false                     # Whether to resume from last checkpoint (true/false)
+process_prot_data: true          # If true, process protein data from scratch. If false, load from output/data/proteinAbundance.csv
 
 # ---- DATA SETTINGS ----
 data_type: prot                 # Type of data: "prot" for proteomics (default), "phospho" for phosphoproteomics

--- a/docs/Workflow.md
+++ b/docs/Workflow.md
@@ -99,7 +99,7 @@ The `steps` list has one entry per pipeline step, appended as each step complete
 ]
 ```
 
-Because the file is flushed to disk after every step, a partial `steps` list is preserved even if the run crashes — which is what the resume feature uses (see `resume` in the config docs).
+Because the file is flushed to disk after every step, a partial `steps` list is preserved even if the run crashes.
 
 ## Refs
 Martinez-Val, A., Bekker-Jensen, D.B., Hogrebe, A., Olsen, J.V. (2021). Data Processing and Analysis for DIA-Based Phosphoproteomics Using Spectronaut. In: Cecconi, D. (eds) Proteomics Data Analysis. Methods in Molecular Biology, vol 2361. Humana, New York, NY. https://doi.org/10.1007/978-1-0716-1641-3_6

--- a/docs/Workflow.md
+++ b/docs/Workflow.md
@@ -64,6 +64,43 @@ This script:
 Output
 You will find the report at: `<repo-root>/<outPath>/report-out.html`. All embedded content (tables, images, version hashes) is included in the single HTML file for easy sharing.
 
+## Run Metadata
+
+Every run automatically writes a `run_metadata.json` file to `<outPath>/` — no config needed. It records everything required to reproduce or audit a run:
+
+| Field | Description |
+|---|---|
+| `start_time` / `end_time` | ISO-8601 UTC timestamps |
+| `exit_status` | `"success"` or `"error"` |
+| `error` | Exception message (only present on error) |
+| `input_files` | SHA-256 hash of each input file |
+| `config` | Full config snapshot |
+| `args` | Command-line arguments |
+| `git` | Commit SHA, nearest tag, dirty flag, path to diff patch |
+| `conda` | `conda list` output for `auto-proteomics` and `r-limma-env` |
+| `platform` | OS and Python platform string |
+| `resources` | Peak memory (MB) and CPU time (s), if psutil is available |
+| `steps` | Timestamped entry for each completed pipeline step (see below) |
+
+If the working tree has uncommitted changes at run time, the full diff is written to `<outPath>/run_diff.patch` so the exact code state can be reproduced later.
+
+### Steps list
+
+The `steps` list has one entry per pipeline step, appended as each step completes:
+
+```json
+"steps": [
+  {"step": "data_processing",      "status": "success", "timestamp": "2026-03-12T10:00:01Z"},
+  {"step": "full_dataset_analysis","status": "success", "timestamp": "2026-03-12T10:02:14Z"},
+  {"step": "subset_timepoint_1",   "status": "success", "timestamp": "2026-03-12T10:04:55Z"},
+  {"step": "report_generation",    "status": "success", "timestamp": "2026-03-12T10:05:03Z"},
+  {"step": "tidy_up",              "status": "success", "timestamp": "2026-03-12T10:05:04Z",
+   "details": {"deleted_files": ["full_dataset/data/treatment_1_treatment_2/limma_output.csv"]}}
+]
+```
+
+Because the file is flushed to disk after every step, a partial `steps` list is preserved even if the run crashes — which is what the resume feature uses (see `resume` in the config docs).
+
 ## Refs
 Martinez-Val, A., Bekker-Jensen, D.B., Hogrebe, A., Olsen, J.V. (2021). Data Processing and Analysis for DIA-Based Phosphoproteomics Using Spectronaut. In: Cecconi, D. (eds) Proteomics Data Analysis. Methods in Molecular Biology, vol 2361. Humana, New York, NY. https://doi.org/10.1007/978-1-0716-1641-3_6
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -95,7 +95,8 @@ To make the code work, you must enter the correct parameters and combination of 
 
 ### Run Settings
 
-**resume.** Whether to resume a previous incomplete run. If `true`, the pipeline reads `<outPath>/run_metadata.json`, identifies steps already marked `success`, and skips them. `data_processing` always re-runs to reconstruct in-memory state. Can also be enabled at the command line with `--resume` (overrides this field). Default: `false`.
+**process_prot_data.** Whether to complete the full protein data processing. If you have already done the data processing and have a `data/proteinAbundance.csv` file to use, set this to false to save a few seconds. If true (default), process protein data from scratch. If false, load from `output/data/proteinAbundance.csv`. 
+
 
 ### Input Data
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -93,6 +93,10 @@ We want this tool to be accessible for people with limited coding experience. Th
 
 To make the code work, you must enter the correct parameters and combination of parameters. For example, if you change the input file but not the output file, it will overwrite any previous output in the output file.
 
+### Run Settings
+
+**resume.** Whether to resume a previous incomplete run. If `true`, the pipeline reads `<outPath>/run_metadata.json`, identifies steps already marked `success`, and skips them. `data_processing` always re-runs to reconstruct in-memory state. Can also be enabled at the command line with `--resume` (overrides this field). Default: `false`.
+
 ### Input Data
 
 **data_type.** Type of data. Options:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@
 
 ## Import libraries
 import os
-import subprocess
+import sys
 
 import yaml
 
@@ -20,6 +20,8 @@ import autoprot.utils.check_env as env
 from autoprot.utils.data_io import make_outdir
 from autoprot.utils.data_utils import get_subset, tidy_up_files
 from autoprot.reporting.generate_report import generate_report_html
+from autoprot.utils.metadata_recording import log_run_metadata, finalise_run_metadata
+
 
 
 ##### Define main function for creating outputs
@@ -135,6 +137,21 @@ def main():
     
     # remove intermediate files
     tidy_up_files(outPath)
+
+    ## Record run metadata
+    input_files = [proteinDataPath, metadataPath, config_path]
+
+    # Start logging
+    metadata_file, metadata = log_run_metadata(input_files, libs, sys.argv)
+
+    # ---- Your pipeline code here ----
+    print("Running pipeline...")
+    # Example: process data, generate HTML, etc.
+
+    # Finalize metadata
+    finalise_run_metadata(metadata_file, metadata)
+    print(f"Metadata logged to {metadata_file} and run_diff.patch (if dirty).")
+
 
 
     

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ def main():
     run_metadata_file = os.path.join(outPath, 'run_metadata', 'run_metadata.yaml')
     run_metadata_file, run_meta = log_run_metadata(
         input_files=input_files, args=sys.argv, config=config,
-        out_path=outPath, run_metadata_file=run_metadata_file,
+        run_metadata_file=run_metadata_file,
         repo_root=REPO_ROOT,
     )
 

--- a/main.py
+++ b/main.py
@@ -4,9 +4,11 @@
 ## Inputs must be protein abundance file and metadata, as specified below and in the github README.
 
 ## Import libraries
+import json
 import os
 import sys
 
+import pandas as pd
 import yaml
 
 import autoprot.analysis.analysis as an
@@ -20,9 +22,7 @@ import autoprot.utils.check_env as env
 from autoprot.utils.data_io import make_outdir
 from autoprot.utils.data_utils import get_subset, tidy_up_files
 from autoprot.reporting.generate_report import generate_report_html
-from autoprot.utils.metadata_recording import log_run_metadata, finalise_run_metadata
-
-
+from autoprot.utils.metadata_recording import log_run_metadata, load_run_metadata, finalise_run_metadata, record_step_complete
 
 ##### Define main function for creating outputs
 def main():
@@ -55,106 +55,130 @@ def main():
     subset_formula = config["DE_subset_formula"]
     # Create the output directory
     make_outdir(outPath, make_subdirs=True)
-    # Data processing
-    print("Loading and processing data...")
-    # metadata
-    metadata = dp.process_data(
-        file_path=metadataPath, json_out=json_out, outPath=outPath, config=config
-    )
-    # protein abundance data
-    df_protAbundance = dp.process_data(
-        file_path=proteinDataPath,
-        metadata=metadata,
-        json_out=json_out,
-        outPath=outPath,
-        config=config,
-    )
-    # if you have already processed the data and want to read in a previously saved version
-    # import pandas as pd; df_protAbundance = pd.read_csv(os.path.join(outPath, "data/proteinAbundance.csv"))
-
-    print("Data loaded and processed...")
-    # Analysis
-    print("Running analysis...")
-
-    # if subsetting not required, go through with full datasets
-    if config["analyse_full_dataset"] is True:
-        full_outPath = os.path.join(outPath, "full_dataset")
-        make_outdir(full_outPath)
-        an.run_analysis(
-            df=df_protAbundance,
-            metadata=metadata,
-            json_out=json_out,
-            output_dir=full_outPath,
-            config=config,
-            formula=full_formula,
-        )
-        print("Full analysis complete.")
-    if config["analyse_subsets"] is True:
-        # Read subsets from config
-        if not config["subsets"]:
-            subset_terms = metadata[config["subset_variable"]].unique()
-        if config["subsets"]:
-            subset_terms = list(config["subsets"])
-        # Loop through subsets
-        for subset in subset_terms:
-            print(f"Processing subset: {subset}")
-            subset_variable = config["subset_variable"]
-            ### find the rows in metadata that match the subset term
-            subset_metadata = metadata.loc[
-                metadata[subset_variable].astype(str) == str(subset),
-            ]
-            # Subset data based on index search term
-            subset_df = get_subset(
-                df=df_protAbundance,
-                subset_term=subset,
-                metadata=subset_metadata,
-                subset_variable=subset_variable,
-            )
-            # Create a new output directory for the subset
-            # if subset has a space in it, replace with _
-            if " " in str(subset):
-                subset = str(subset).replace(" ", "_")
-            subset_outPath = os.path.join(
-                outPath, "subsets", subset_variable + "_" + str(subset)
-            )
-            make_outdir(subset_outPath, make_subdirs=True)
-            # Run analysis for the subset
-            print(f"Running analysis for {subset}...")
-            an.run_analysis(
-                df=subset_df,
-                metadata=subset_metadata,
-                json_out=json_out,
-                output_dir=subset_outPath,
-                config=config,
-                formula=subset_formula,
-            )
-        print("All subsets processed successfully.")
-
-    print("generating html report...")
-    generate_report_html(config = config)
-
-    print("Analysis complete. Outputs saved to output directory. Tidying up intermediate files")
-    
-    # remove intermediate files
-    tidy_up_files(outPath)
 
     ## Record run metadata
     input_files = [proteinDataPath, metadataPath, config_path]
+    run_metadata_file = os.path.join(outPath, 'run_metadata.json')
 
-    # Start logging
-    metadata_file, metadata = log_run_metadata(input_files, libs, sys.argv)
+    # Resume detection: opt in via --resume flag or config field
+    resume_requested = '--resume' in sys.argv or config.get('resume', False)
 
-    # ---- Your pipeline code here ----
-    print("Running pipeline...")
-    # Example: process data, generate HTML, etc.
+    if resume_requested and os.path.exists(run_metadata_file):
+        run_meta, completed_steps = load_run_metadata(run_metadata_file)
+        print(f"Resuming incomplete run. Already completed: {completed_steps}")
+    else:
+        completed_steps = set()
+        run_metadata_file, run_meta = log_run_metadata(
+            input_files=input_files, args=sys.argv, config=config,
+            out_path=outPath, run_metadata_file=run_metadata_file
+        )
 
-    # Finalize metadata
-    finalise_run_metadata(metadata_file, metadata)
-    print(f"Metadata logged to {metadata_file} and run_diff.patch (if dirty).")
+    try:
+        # Data processing
+        print("Loading and processing data...")
+        # metadata is always recomputed (fast, needed to reconstruct in-memory state)
+        metadata = dp.process_data(
+            file_path=metadataPath, json_out=json_out, outPath=outPath, config=config
+        )
+
+        if 'data_processing' not in completed_steps:
+            df_protAbundance = dp.process_data(
+                file_path=proteinDataPath,
+                metadata=metadata,
+                json_out=json_out,
+                outPath=outPath,
+                config=config,
+            )
+            print("Data loaded and processed...")
+            record_step_complete("data_processing", "success", run_meta, run_metadata_file)
+        else:
+            print("Resuming — loading proteinAbundance from file...")
+            df_protAbundance = pd.read_csv(os.path.join(outPath, "data", "proteinAbundance.csv"), index_col=0)
+
+        # Analysis
+        print("Running analysis...")
+
+        # if subsetting not required, go through with full datasets
+        if config["analyse_full_dataset"] is True and 'full_dataset_analysis' not in completed_steps:
+            full_outPath = os.path.join(outPath, "full_dataset")
+            make_outdir(full_outPath)
+            an.run_analysis(
+                df=df_protAbundance,
+                metadata=metadata,
+                json_out=json_out,
+                output_dir=full_outPath,
+                config=config,
+                formula=full_formula,
+            )
+            print("Full analysis complete.")
+            record_step_complete("full_dataset_analysis", "success", run_meta, run_metadata_file)
+
+        if config["analyse_subsets"] is True:
+            # Read subsets from config
+            if not config["subsets"]:
+                subset_terms = metadata[config["subset_variable"]].unique()
+            if config["subsets"]:
+                subset_terms = list(config["subsets"])
+            # Loop through subsets
+            for subset in subset_terms:
+                step_name = f"subset_{str(subset).replace(' ', '_')}"
+                if step_name in completed_steps:
+                    print(f"Skipping already-completed subset: {subset}")
+                    continue
+                print(f"Processing subset: {subset}")
+                subset_variable = config["subset_variable"]
+                ### find the rows in metadata that match the subset term
+                subset_metadata = metadata.loc[
+                    metadata[subset_variable].astype(str) == str(subset),
+                ]
+                # Subset data based on index search term
+                subset_df = get_subset(
+                    df=df_protAbundance,
+                    subset_term=subset,
+                    metadata=subset_metadata,
+                    subset_variable=subset_variable,
+                )
+                # Create a new output directory for the subset
+                # if subset has a space in it, replace with _
+                if " " in str(subset):
+                    subset = str(subset).replace(" ", "_")
+                subset_outPath = os.path.join(
+                    outPath, "subsets", subset_variable + "_" + str(subset)
+                )
+                make_outdir(subset_outPath, make_subdirs=True)
+                # Run analysis for the subset
+                print(f"Running analysis for {subset}...")
+                an.run_analysis(
+                    df=subset_df,
+                    metadata=subset_metadata,
+                    json_out=json_out,
+                    output_dir=subset_outPath,
+                    config=config,
+                    formula=subset_formula,
+                )
+                record_step_complete(step_name, "success", run_meta, run_metadata_file)
+            print("All subsets processed successfully.")
+
+        if 'report_generation' not in completed_steps:
+            print("generating html report...")
+            generate_report_html(config=config)
+            record_step_complete("report_generation", "success", run_meta, run_metadata_file)
+
+        if 'tidy_up' not in completed_steps:
+            print("Analysis complete. Outputs saved to output directory. Tidying up intermediate files")
+            deleted = tidy_up_files(outPath)
+            record_step_complete("tidy_up", "success", run_meta, run_metadata_file,
+                                 details={"deleted_files": deleted})
+
+        # Finalize metadata
+        finalise_run_metadata(run_metadata_file, run_meta, exit_status='success')
+        print(f"Metadata logged to {run_metadata_file} and run_diff.patch (if dirty).")
+
+    except Exception as e:
+        finalise_run_metadata(run_metadata_file, run_meta, exit_status='error', error=str(e))
+        raise
 
 
-
-    
 #### If executed in main script, run the function to produce the output
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@
 ## Inputs must be protein abundance file and metadata, as specified below and in the github README.
 
 ## Import libraries
-import json
 import os
 import sys
 
@@ -22,7 +21,7 @@ import autoprot.utils.check_env as env
 from autoprot.utils.data_io import make_outdir
 from autoprot.utils.data_utils import get_subset, tidy_up_files
 from autoprot.reporting.generate_report import generate_report_html
-from autoprot.utils.metadata_recording import log_run_metadata, load_run_metadata, finalise_run_metadata, record_step_complete
+from autoprot.utils.metadata_recording import log_run_metadata, finalise_run_metadata, record_step_complete
 
 ##### Define main function for creating outputs
 def main():
@@ -58,20 +57,12 @@ def main():
 
     ## Record run metadata
     input_files = [proteinDataPath, metadataPath, config_path]
-    run_metadata_file = os.path.join(outPath, 'run_metadata.json')
-
-    # Resume detection: opt in via --resume flag or config field
-    resume_requested = '--resume' in sys.argv or config.get('resume', False)
-
-    if resume_requested and os.path.exists(run_metadata_file):
-        run_meta, completed_steps = load_run_metadata(run_metadata_file)
-        print(f"Resuming incomplete run. Already completed: {completed_steps}")
-    else:
-        completed_steps = set()
-        run_metadata_file, run_meta = log_run_metadata(
-            input_files=input_files, args=sys.argv, config=config,
-            out_path=outPath, run_metadata_file=run_metadata_file
-        )
+    run_metadata_file = os.path.join(outPath, 'run_metadata', 'run_metadata.yaml')
+    run_metadata_file, run_meta = log_run_metadata(
+        input_files=input_files, args=sys.argv, config=config,
+        out_path=outPath, run_metadata_file=run_metadata_file,
+        repo_root=REPO_ROOT,
+    )
 
     try:
         # Data processing
@@ -81,7 +72,7 @@ def main():
             file_path=metadataPath, json_out=json_out, outPath=outPath, config=config
         )
 
-        if 'data_processing' not in completed_steps:
+        if config.get('process_prot_data', True):
             df_protAbundance = dp.process_data(
                 file_path=proteinDataPath,
                 metadata=metadata,
@@ -92,20 +83,20 @@ def main():
             print("Data loaded and processed...")
             record_step_complete("data_processing", "success", run_meta, run_metadata_file)
         else:
-            print("Resuming — loading proteinAbundance from file...")
+            print("Skipping protein data processing — loading proteinAbundance from file...")
             df_protAbundance = pd.read_csv(os.path.join(outPath, "data", "proteinAbundance.csv"), index_col=0)
+            record_step_complete("data_processing", "skipped", run_meta, run_metadata_file)
 
         # Analysis
         print("Running analysis...")
 
         # if subsetting not required, go through with full datasets
-        if config["analyse_full_dataset"] is True and 'full_dataset_analysis' not in completed_steps:
+        if config["analyse_full_dataset"] is True:
             full_outPath = os.path.join(outPath, "full_dataset")
             make_outdir(full_outPath)
             an.run_analysis(
                 df=df_protAbundance,
                 metadata=metadata,
-                json_out=json_out,
                 output_dir=full_outPath,
                 config=config,
                 formula=full_formula,
@@ -122,9 +113,6 @@ def main():
             # Loop through subsets
             for subset in subset_terms:
                 step_name = f"subset_{str(subset).replace(' ', '_')}"
-                if step_name in completed_steps:
-                    print(f"Skipping already-completed subset: {subset}")
-                    continue
                 print(f"Processing subset: {subset}")
                 subset_variable = config["subset_variable"]
                 ### find the rows in metadata that match the subset term
@@ -159,20 +147,18 @@ def main():
                 record_step_complete(step_name, "success", run_meta, run_metadata_file)
             print("All subsets processed successfully.")
 
-        if 'report_generation' not in completed_steps:
-            print("generating html report...")
-            generate_report_html(config=config)
-            record_step_complete("report_generation", "success", run_meta, run_metadata_file)
+        print("generating html report...")
+        generate_report_html(config=config)
+        record_step_complete("report_generation", "success", run_meta, run_metadata_file)
 
-        if 'tidy_up' not in completed_steps:
-            print("Analysis complete. Outputs saved to output directory. Tidying up intermediate files")
-            deleted = tidy_up_files(outPath)
-            record_step_complete("tidy_up", "success", run_meta, run_metadata_file,
-                                 details={"deleted_files": deleted})
+        print("Analysis complete. Outputs saved to output directory. Tidying up intermediate files")
+        deleted = tidy_up_files(outPath)
+        record_step_complete("tidy_up", "success", run_meta, run_metadata_file,
+                             details={"deleted_files": deleted})
 
         # Finalize metadata
         finalise_run_metadata(run_metadata_file, run_meta, exit_status='success')
-        print(f"Metadata logged to {run_metadata_file} and run_diff.patch (if dirty).")
+        print(f"Metadata logged to {run_metadata_file} (conda_envs/ and run_diff.patch alongside if applicable).")
 
     except Exception as e:
         finalise_run_metadata(run_metadata_file, run_meta, exit_status='error', error=str(e))

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -88,8 +88,3 @@ def test_run_analysis_end_to_end():
 
         # Combined plots
         assert (tmpdir_path / "plots/combined_volcano_plot.png").exists()
-
-        # Version metadata
-        with open(json_out) as f:
-            meta = yaml.safe_load(f)
-        assert "ANALYSIS_VERSION" in meta

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -55,21 +54,15 @@ def test_run_analysis_end_to_end():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
-        json_out = tmpdir_path / "metadata.json"
 
         os.makedirs(tmpdir_path / "plots")
         os.makedirs(tmpdir_path / "data")
-
-        # Start with empty metadata file
-        with open(json_out, "w") as f:
-            json.dump({}, f)
 
         results = run_analysis(
             df=df,
             metadata=metadata,
             output_dir=str(tmpdir_path),
             config=config,
-            json_out=str(json_out),
             formula=config["formula"],
         )
 

--- a/tests/test_data_preprocess.py
+++ b/tests/test_data_preprocess.py
@@ -36,8 +36,11 @@ def test_filter_proteins_by_group_missingness_with_spike(
     for prot in [f"Prot{i}" for i in range(90, 100)]:
         df.loc[prot, ["S0", "S1", "S2"]] = np.nan
 
+    # filter_proteins_by_group_missingness expects config file with field 'missing_threshold'
+    config = {"missing_threshold": 0.6}
+
     # Run filter at 0.6 threshold (must be present in ≥60% of samples per group)
-    filtered_df = filter_proteins_by_group_missingness(df, metadata, threshold=0.6)
+    filtered_df = filter_proteins_by_group_missingness(df, metadata, config = config)
 
     # Make sure spiked proteins are kept (they should be complete)
     assert all(p in filtered_df.index for p in spiked_proteins[:5])

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -99,7 +99,7 @@ def test_clean_prot():
     )
 
     # 3. Call clean_prot
-    cleaned_df, _ = clean_prot(df.copy(), metadata)
+    cleaned_df = clean_prot(df.copy(), metadata)
 
     # 4. It should drop the unrelated column
     assert "unrelated_column" not in cleaned_df.columns
@@ -151,13 +151,13 @@ def test_prot_summary(tmp_path):
     assert data["NUM_PROTS"] == "2"
 
     # Minimum mean → 2.0, formatted with `:,.0f` → "2"
-    assert data["MIN_AVERAGE_ABUNDANCE"] == "2"
+    assert data["MIN_AVERAGE_ABUNDANCE"] == "2.00"
 
     # Maximum mean → 3.0 → "3"
-    assert data["MAX_AVERAGE_ABUNDANCE"] == "3"
+    assert data["MAX_AVERAGE_ABUNDANCE"] == "3.00"
 
     # Median of [2.0, 3.0] is 2.5, `:,.0f` rounds to "2"
-    assert data["MEDIAN_AVERAGE_ABUNDANCE"] == "2"
+    assert data["MEDIAN_AVERAGE_ABUNDANCE"] == "2.50"
 
 
 # ────────────────────────────────────────────────────
@@ -238,15 +238,17 @@ def test_clean_data(tmp_path, monkeypatch):
         "normalise_method": "sample-median",
         "imputation_method": "hist_grad_boost",
     }
+    
+    prot_out = Path(tmp_path) / "proteindata.csv"
 
-    df = normalise_column_names(df, file_path="path/to/proteindata.csv", config=config)
+    df = normalise_column_names(df, file_path=prot_out, config=config, outPath=tmp_path)
 
     # ────────────────────────────────────────────────────
     # 6) Run the pipeline
     # ────────────────────────────────────────────────────
     cleaned_df = clean_data(
         df.copy(),
-        file_path="path/to/proteindata.csv",
+        file_path=prot_out,
         metadata=metadata,
         outPath=str(tmp_path),
         config=config,
@@ -325,6 +327,7 @@ def test_process_data_proteindata_branch(monkeypatch, tmp_path):
     """Test the process_data function from data_processing.py with proteindata branch."""
 
     monkeypatch.setattr(dpp, "view_prot_distributions", lambda *a, **k: None)
+    os.makedirs(tmp_path / "data")
 
     # 1) Create a tiny proteindata CSV (two columns)
     long_cols = [
@@ -333,14 +336,14 @@ def test_process_data_proteindata_branch(monkeypatch, tmp_path):
     ]
     prot_df = pd.DataFrame(
         {
+            "pg.genes": [np.nan, "p2", "p3", "p4", "p4"],
             long_cols[0]: [1, 0, "x", 6, 6],
             long_cols[1]: [4, 5, 6, 6, 6],
-        },
-        index=[np.nan, "p2", "p3", "p4", "p4"],
+        }
     )
 
     prot_path = Path(tmp_path) / "my_proteindata.csv"
-    prot_df.to_csv(prot_path)
+    prot_df.to_csv(prot_path, index=False)
 
     # 2) Build matching metadata (so clean_data won’t error)
     metadata = pd.DataFrame(
@@ -384,4 +387,4 @@ def test_process_data_proteindata_branch(monkeypatch, tmp_path):
     # Columns must now be your sample_rep names
     assert set(result.columns) == {"S1_1", "S2_1"}
     ### two prots should be left
-    assert ("Unknown-gene-1" in result.index) and ("p4" in result.index)
+    assert ("Unknown-gene-1" in result.index) and ("p4-1" in result.index) # note additional -1 suffix to p4 due to duplicate removal

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -324,11 +324,9 @@ def test_combine_plots_creates_output(image_dir_with_pngs):
     output_dir = tempfile.mkdtemp()
 
     combine_plots(
-        search_term="volcano_plot.png",
+        search_term="volcano",
         search_path=image_dir_with_pngs,
         output_dir=output_dir,
-        img_size=(100, 100),
-        max_cols=2,
     )
 
     # Final path based on default combine logic

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -4,22 +4,37 @@ import tempfile
 
 import pandas as pd
 import pytest
+from PIL import Image
 
 from autoprot.reporting.generate_report import generate_report_html
+import autoprot.utils.check_env as ce
 
 
 @pytest.fixture
 def mock_report_setup():
     with tempfile.TemporaryDirectory() as temp_dir:
-        # Simulate minimal config
-        config = {
-            "outPath": os.path.join(temp_dir, "output"),
-            "json_outPath": os.path.join(temp_dir, "metadata.json"),
-        }
-        os.makedirs(config["outPath"], exist_ok=True)
+        # Create directory structure matching what generate_report_html expects
+        data_dir = os.path.join(temp_dir, "full_dataset/data")
+        plots_dir = os.path.join(temp_dir, "full_dataset/plots")
+        report_dir = os.path.join(temp_dir, "report")
+        os.makedirs(data_dir, exist_ok=True)
+        os.makedirs(plots_dir, exist_ok=True)
+        os.makedirs(report_dir, exist_ok=True)
 
-        # Create dummy report template with placeholders
-        template_md = os.path.join(temp_dir, "template.md")
+        # Config matching what generate_report_html reads from
+        config = {
+            "outPath": temp_dir,
+            "json_outPath": os.path.join(temp_dir, "metadata.json"),
+            "missing_threshold": 0.5,
+            "df_to_use": "df_imp",
+            "normalise_method": "sample-median",
+            "imputation_method": "hist_grad_boost",
+            "FDR_threshold": 0.05,
+        }
+
+        # Report template at the path get_repo_root() + ./report/report-template.md
+        # monkeypatch get_repo_root to return temp_dir so paths resolve correctly
+        template_md = os.path.join(report_dir, "report-template.md")
         with open(template_md, "w") as f:
             f.write(
                 "# Report\n\n"
@@ -29,127 +44,54 @@ def mock_report_setup():
                 "{{ENRICHMENT_PLOT}}\n"
             )
 
-        # Create dummy top LFC CSV
-        top_lfc_csv = os.path.join(temp_dir, "top_lfc.csv")
+        # Top LFC CSV at expected path
         pd.DataFrame({"gene": ["A", "B"], "logFC": [1.2, -0.8]}).to_csv(
-            top_lfc_csv, index=False
+            os.path.join(data_dir, "combined_topLFC.csv"), index=False
         )
 
-        # Create dummy enrichment CSV
-        enrich_csv = os.path.join(temp_dir, "enrich.csv")
-        pd.DataFrame(
-            {
-                "source": ["GO"],
-                "native": ["GO:0001"],
-                "name": ["test pathway"],
-                "p_value": [0.01],
-                "term_size": [10],
-                "query_size": [5],
-                "intersection_size": [2],
-                "precision": [0.4],
-                "recall": [0.2],
-                "treatment_pair": ["A_vs_B"],
-            }
-        ).to_csv(enrich_csv, index=False)
+        # Enrichment CSV at expected path
+        pd.DataFrame({
+            "source": ["GO"],
+            "native": ["GO:0001"],
+            "name": ["test pathway"],
+            "p_value": [0.01],
+            "term_size": [10],
+            "query_size": [5],
+            "intersection_size": [2],
+            "precision": [0.4],
+            "recall": [0.2],
+            "treatment_pair": ["A_vs_B"],
+        }).to_csv(os.path.join(data_dir, "combined_top_pathway_enrichment.csv"), index=False)
 
-        # Create dummy image
-        enrich_img = os.path.join(temp_dir, "plot.png")
-        with open(enrich_img, "wb") as f:
-            f.write(
-                b"\x89PNG\r\n\x1a\n" + b"0" * 100
-            )  # minimal PNG header + dummy content
+        # Dummy enrichment plot
+        img = Image.new("RGB", (100, 100), color=(255, 0, 0))
+        img.save(os.path.join(plots_dir, "combined_pathway_enrichment_plot.png"))
 
-        # Create JSON metadata with a PROJECT_NAME key
+        # Starter JSON
         with open(config["json_outPath"], "w") as f:
             json.dump({"PROJECT_NAME": "Test Project"}, f)
 
-        # HTML output path
-        report_html = os.path.join(config["outPath"], "report.html")
-
-        yield {
-            "report_MD": template_md,
-            "report_html": report_html,
-            "top_LFC_prots_path": top_lfc_csv,
-            "enrichment_path": enrich_csv,
-            "enrichment_plot_path": enrich_img,
-            "json_out": config["json_outPath"],
-            "config": config,
-        }
+        yield config
 
 
-def test_generate_report_html_generates_file(mock_report_setup):
-    args = mock_report_setup
-    generate_report_html(**args)
+def test_generate_report_html_generates_file(mock_report_setup, monkeypatch):
+    config = mock_report_setup
+    
+    # make get_repo_root return temp_dir so internal path joins resolve correctly
+    monkeypatch.setattr(ce, "get_repo_root", lambda: config["outPath"])
+    
+    generate_report_html(config=config)
 
-    # Check HTML file exists
-    assert os.path.exists(args["report_html"])
-    with open(args["report_html"]) as f:
+    report_html = os.path.join(config["outPath"], "report-out.html")
+    assert os.path.exists(report_html)
+    
+    with open(report_html) as f:
         html = f.read()
-        assert "Test Project" in html
-        assert "test pathway" in html
+        assert "Protein Abundance Exploratory Analysis" in html
         assert "<img" in html or "No pathway enrichment plot" in html
 
-    # Check that metadata JSON has git hashes recorded
-    with open(args["json_out"]) as f:
+    with open(config["json_outPath"]) as f:
         meta = json.load(f)
-        assert "GENERATE_REPORT_VERSION" in meta
-        assert "TEMPLATE_VERSION" in meta
-
-
-# def test_generate_report_html_patch(tmp_path):
-#      # Fake the 'markdown' module before anything imports it
-#     sys.modules["markdown"] = types.SimpleNamespace(markdown=lambda x: f"<p>{x}</p>")
-
-#     # Now you can import safely
-#     from autoprot.reporting.generate_report import generate_report_html
-
-#     # Set up dummy paths
-#     report_md_path = tmp_path / "template.md"
-#     report_html_path = tmp_path / "report.html"
-#     top_lfc_path = tmp_path / "toplfc.csv"
-#     enrichment_path = tmp_path / "enrich.csv"
-#     enrichment_plot_path = tmp_path / "enrich.png"
-#     json_out_path = tmp_path / "data.json"
-
-#     # Write template
-#     report_md_path.write_text("""
-#     <html>
-#     <body>
-#     <h1>Report</h1>
-#     $GENERATE_REPORT_VERSION
-#     {{TOP_LFC_PROTS}}
-#     {{ENRICHMENT_DF}}
-#     {{ENRICHMENT_PLOT}}
-#     </body>
-#     </html>
-#     """)
-
-#     # Write data
-#     pd.DataFrame({"Protein": ["P1", "P2"], "logFC": [2.1, -1.3]}).to_csv(top_lfc_path, index=False)
-#     pd.DataFrame({
-#         "source": ["GO"], "native": ["GO:00001"], "name": ["term1"], "p_value": [0.01],
-#         "term_size": [50], "query_size": [10], "intersection_size": [5],
-#         "precision": [0.5], "recall": [0.6], "treatment_pair": ["A_vs_B"]
-#     }).to_csv(enrichment_path, index=False)
-#     enrichment_plot_path.write_bytes(b"fake image")
-#     json_out_path.write_text("{}")
-
-#     # Patch markdown and git
-#     with mock.patch("subprocess.check_output", return_value=b"dummyhash"), \
-#          mock.patch("markdown.markdown", return_value="<p>Rendered HTML</p>"):
-
-#         generate_report_html(
-#             str(report_md_path),
-#             str(report_html_path),
-#             str(top_lfc_path),
-#             str(enrichment_path),
-#             str(enrichment_plot_path),
-#             str(json_out_path)
-#         )
-
-#     # Check HTML output
-#     assert report_html_path.exists()
-#     html = report_html_path.read_text()
-#     assert "Rendered HTML" in html
-#     assert "dummyhash" not in html  # replaced before markdown conversion
-#     assert "<p>" in html
+        assert meta["PROJECT_NAME"] == "Test Project"
+        assert 'IMP_METHOD' in meta
+        assert 'NORM_METHOD' in meta

--- a/tests/test_metadata_recording.py
+++ b/tests/test_metadata_recording.py
@@ -1,0 +1,435 @@
+"""Unit tests for run_metadata.py.
+
+Structure mirrors the module: one section per public function, in the order
+they are typically called during a pipeline run.
+
+Subprocess calls (git, conda) are always mocked so tests run without a git
+repo or conda installation. File I/O uses pytest's `tmp_path` fixture, which
+provides a fresh temporary directory per test that is cleaned up automatically.
+
+Mocking approach
+----------------
+@patch replaces the named object for the duration of a single test. When
+stacking multiple @patch decorators, the innermost decorator maps to the
+first extra argument, i.e.:
+
+    @patch("module.outer")   ->  second extra arg (mock_outer)
+    @patch("module.inner")   ->  first extra arg  (mock_inner)
+    def test_foo(mock_inner, mock_outer): ...
+
+side_effect on a mock returns different values on successive calls, used to
+simulate multiple subprocess.check_output calls (e.g. git rev-parse, then
+git diff, then git describe).
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import autoprot.utils.metadata_recording as rm
+
+
+# ---------------------------------------------------------------------------
+# file_hash
+# ---------------------------------------------------------------------------
+
+def test_file_hash_known_value(tmp_path):
+    """file_hash produces the correct SHA-256 digest for a known input.
+
+    We independently compute the expected hash with hashlib and compare,
+    confirming the function is not just returning a constant or truncating.
+    """
+    import hashlib
+    content = b"hello world"
+    f = tmp_path / "test.txt"
+    f.write_bytes(content)
+    expected = hashlib.sha256(content).hexdigest()
+    assert rm.file_hash(str(f)) == expected
+
+
+def test_file_hash_empty_file(tmp_path):
+    """file_hash handles an empty file correctly.
+
+    The SHA-256 of an empty byte string is a well-known constant, so this
+    also serves as a cross-check that the function reads the file rather than
+    hashing the path string or some other artefact.
+    """
+    f = tmp_path / "empty.txt"
+    f.write_bytes(b"")
+    assert rm.file_hash(str(f)) == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+def test_file_hash_different_files_differ(tmp_path):
+    """file_hash returns distinct digests for files with different content.
+
+    Guards against a broken implementation that returns the same value
+    regardless of content.
+    """
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "b.txt"
+    f1.write_bytes(b"aaa")
+    f2.write_bytes(b"bbb")
+    assert rm.file_hash(str(f1)) != rm.file_hash(str(f2))
+
+
+# ---------------------------------------------------------------------------
+# _utcnow
+# ---------------------------------------------------------------------------
+
+def test_utcnow_is_iso_string():
+    """_utcnow returns a timezone-aware ISO-8601 timestamp string.
+
+    We parse the result with datetime.fromisoformat and check that tzinfo is
+    set, confirming the string is both valid ISO-8601 and explicitly UTC
+    rather than a naive local timestamp.
+    """
+    from datetime import datetime, timezone
+    result = rm._utcnow()
+    parsed = datetime.fromisoformat(result)
+    assert parsed.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# get_git_info
+# ---------------------------------------------------------------------------
+
+# A fake 36-character commit SHA used throughout git tests.
+GOOD_COMMIT = "abc123def456" * 3
+
+
+@patch("autoprot.utils.metadata_recording.subprocess.check_output")
+@patch("autoprot.utils.metadata_recording.subprocess.call")
+def test_get_git_info_clean_repo(mock_call, mock_output):
+    """get_git_info returns commit, tag, dirty=False when working tree is clean.
+
+    subprocess.call (used for git diff-index) returns 0 to signal a clean
+    tree. check_output is called twice: once for rev-parse HEAD and once for
+    git describe. We verify all four returned keys are populated correctly and
+    diff_file is None (no patch should be written for a clean repo).
+    """
+    mock_output.side_effect = [
+        (GOOD_COMMIT + "\n").encode(),   # first call:  git rev-parse HEAD
+        b"v1.2.3\n",                     # second call: git describe --tags
+    ]
+    mock_call.return_value = 0           # 0 = clean working tree
+
+    result = rm.get_git_info()
+
+    assert result["commit"] == GOOD_COMMIT
+    assert result["dirty"] is False
+    assert result["diff_file"] is None
+    assert result["tag"] == "v1.2.3"
+
+
+@patch("autoprot.utils.metadata_recording.subprocess.check_output")
+@patch("autoprot.utils.metadata_recording.subprocess.call")
+def test_get_git_info_dirty_writes_patch(mock_call, mock_output, tmp_path):
+    """get_git_info writes a .patch file and records its path when repo is dirty.
+
+    subprocess.call returns 1 (non-zero = dirty). check_output is called three
+    times: rev-parse HEAD, git diff (output written to the patch file), and
+    git describe. We assert the patch file exists and contains exactly the
+    mocked diff content, confirming the write path works end-to-end.
+    """
+    diff_content = "diff --git a/foo.py b/foo.py\n+new line\n"
+    mock_output.side_effect = [
+        (GOOD_COMMIT + "\n").encode(),   # git rev-parse HEAD
+        diff_content.encode(),           # git diff -> written to patch file
+        b"v1.2.3-1-gabcdef\n",           # git describe
+    ]
+    mock_call.return_value = 1           # 1 = dirty working tree
+
+    patch_file = str(tmp_path / "run.patch")
+    result = rm.get_git_info(diff_file=patch_file)
+
+    assert result["dirty"] is True
+    assert result["diff_file"] == patch_file
+    assert os.path.exists(patch_file)
+    assert open(patch_file).read() == diff_content
+
+
+@patch("autoprot.utils.metadata_recording.subprocess.check_output", side_effect=Exception("no git"))
+@patch("autoprot.utils.metadata_recording.subprocess.call", side_effect=Exception("no git"))
+def test_get_git_info_no_git(mock_call, mock_output):
+    """get_git_info returns all-None dict gracefully when git is unavailable.
+
+    Covers the case where a user has downloaded the code as a zip (no .git
+    directory) or git is simply not installed. The function must not raise;
+    it should return a safe sentinel dict so log_run_metadata can still write
+    valid JSON.
+    """
+    result = rm.get_git_info()
+    assert result == {"commit": None, "tag": None, "dirty": None, "diff_file": None}
+
+
+# ---------------------------------------------------------------------------
+# get_conda_env
+# ---------------------------------------------------------------------------
+
+@patch("autoprot.utils.metadata_recording.subprocess.check_output")
+def test_get_conda_env_active(mock_output):
+    """get_conda_env with no argument queries the currently active environment.
+
+    Checks that 'conda list' is called without a -n flag, and that the raw
+    text output is returned as a decoded string (not bytes).
+    """
+    mock_output.return_value = b"# packages in environment\nnumpy 1.26.0\n"
+    result = rm.get_conda_env()
+    assert "numpy" in result
+    mock_output.assert_called_once_with(["conda", "list"])
+
+
+@patch("autoprot.utils.metadata_recording.subprocess.check_output")
+def test_get_conda_env_named(mock_output):
+    """get_conda_env passes -n <env_name> when an environment name is given.
+
+    The pipeline records both the active auto-proteomics env and the separate
+    r-limma-env. This test confirms the -n flag is forwarded correctly so the
+    right environment is queried.
+    """
+    mock_output.return_value = b"pandas 2.0.0\n"
+    result = rm.get_conda_env("r-limma-env")
+    mock_output.assert_called_once_with(["conda", "list", "-n", "r-limma-env"])
+    assert result == "pandas 2.0.0\n"
+
+
+@patch("autoprot.utils.metadata_recording.subprocess.check_output", side_effect=Exception("conda not found"))
+def test_get_conda_env_failure(mock_output):
+    """get_conda_env returns None rather than raising when conda is unavailable.
+
+    Mirrors the git fallback behaviour: the caller can check for None and
+    still write valid metadata rather than crashing the whole pipeline.
+    """
+    assert rm.get_conda_env() is None
+
+
+# ---------------------------------------------------------------------------
+# log_run_metadata
+# ---------------------------------------------------------------------------
+
+def _mock_git_info(**kwargs):
+    """Return a minimal git info dict, overriding specific keys via kwargs.
+
+    Used to keep log_run_metadata tests readable — we swap in a predictable
+    git state without repeating the full dict in every test.
+    """
+    defaults = {"commit": GOOD_COMMIT, "tag": "v1.0", "dirty": False, "diff_file": None}
+    defaults.update(kwargs)
+    return defaults
+
+
+@patch("autoprot.utils.metadata_recording.get_conda_env", return_value="numpy 1.26\n")
+@patch("autoprot.utils.metadata_recording.get_git_info", return_value=_mock_git_info())
+def test_log_run_metadata_creates_file(mock_git, mock_conda, tmp_path):
+    """log_run_metadata writes a valid JSON file containing all expected keys.
+
+    git and conda calls are mocked so the test does not require a real repo
+    or conda installation. We verify that:
+      - the file is created on disk and is valid JSON
+      - input file hashes, config, git info, and platform are all present
+      - steps is initialised as an empty list (no steps have run yet)
+      - start_time is recorded
+    """
+    input_file = tmp_path / "input.txt"
+    input_file.write_bytes(b"data")
+    out_path = str(tmp_path)
+    meta_file = str(tmp_path / "run_metadata.json")
+
+    result_file, result_meta = rm.log_run_metadata(
+        input_files=[str(input_file)],
+        args=["main.py", "--config", "cfg.yaml"],
+        config={"threshold": 0.05},
+        out_path=out_path,
+        run_metadata_file=meta_file,
+    )
+
+    assert os.path.exists(result_file)
+    with open(result_file) as f:
+        on_disk = json.load(f)
+
+    assert on_disk["git"]["commit"] == GOOD_COMMIT
+    assert on_disk["config"] == {"threshold": 0.05}
+    assert str(input_file) in on_disk["input_files"]
+    assert on_disk["steps"] == []
+    assert "start_time" in on_disk
+    assert "platform" in on_disk
+
+
+# ---------------------------------------------------------------------------
+# load_run_metadata
+# ---------------------------------------------------------------------------
+
+def _write_meta(path, steps):
+    """Write a minimal run_metadata JSON fixture to disk.
+
+    Helper used by load_run_metadata tests to avoid repeating boilerplate.
+    Only includes the fields that load_run_metadata actually reads.
+    """
+    meta = {"start_time": "2024-01-01T00:00:00+00:00", "steps": steps}
+    with open(path, "w") as f:
+        json.dump(meta, f)
+    return meta
+
+
+def test_load_run_metadata_completed_steps(tmp_path):
+    """load_run_metadata returns only 'success' steps in the completed set.
+
+    This set is used during pipeline resume to decide which steps to skip.
+    We include two successful steps and one failed step, and assert that the
+    failed step is excluded — re-running a failed step on resume is
+    intentional behaviour.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    _write_meta(meta_file, [
+        {"step": "data_processing", "status": "success", "timestamp": "t1"},
+        {"step": "normalisation",   "status": "success", "timestamp": "t2"},
+        {"step": "subset_ctrl",     "status": "error",   "timestamp": "t3"},
+    ])
+    meta, completed = rm.load_run_metadata(meta_file)
+    assert completed == {"data_processing", "normalisation"}
+    assert "subset_ctrl" not in completed
+
+
+def test_load_run_metadata_no_steps(tmp_path):
+    """load_run_metadata returns an empty set when no steps have been recorded.
+
+    Covers a fresh run interrupted before any step completed. The function
+    should not crash and should signal that all steps need to be (re-)run.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    _write_meta(meta_file, [])
+    _, completed = rm.load_run_metadata(meta_file)
+    assert completed == set()
+
+
+# ---------------------------------------------------------------------------
+# record_step_complete
+# ---------------------------------------------------------------------------
+
+def test_record_step_complete_appends_and_flushes(tmp_path):
+    """record_step_complete appends each step and keeps the JSON file in sync.
+
+    We call it twice and verify that both the in-memory dict and the on-disk
+    JSON reflect both entries. The flush-to-disk behaviour is critical: if
+    the run is interrupted after this call, the completed step is not lost.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    rm.record_step_complete("data_processing", "success", run_meta, meta_file)
+    rm.record_step_complete("normalisation", "success", run_meta, meta_file)
+
+    assert len(run_meta["steps"]) == 2
+    with open(meta_file) as f:
+        on_disk = json.load(f)
+    assert len(on_disk["steps"]) == 2
+    assert on_disk["steps"][0]["step"] == "data_processing"
+
+
+def test_record_step_complete_with_details(tmp_path):
+    """record_step_complete stores an optional details dict inside the step entry.
+
+    The details argument lets callers attach step-specific metadata (e.g.
+    number of proteins quantified). We confirm the dict is preserved verbatim.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    rm.record_step_complete(
+        "subset_ctrl", "success", run_meta, meta_file,
+        details={"n_proteins": 1200}
+    )
+
+    assert run_meta["steps"][0]["details"] == {"n_proteins": 1200}
+
+
+def test_record_step_complete_error_status(tmp_path):
+    """record_step_complete stores 'error' status faithfully.
+
+    Failed steps must be recorded (not silently dropped) so that resume
+    logic can identify which steps need to be re-run.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    rm.record_step_complete("normalisation", "error", run_meta, meta_file)
+
+    assert run_meta["steps"][0]["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# finalise_run_metadata
+# ---------------------------------------------------------------------------
+
+def test_finalise_adds_end_time_and_status(tmp_path):
+    """finalise_run_metadata adds end_time and exit_status and flushes to disk.
+
+    Both the in-memory dict and the JSON file on disk are checked, confirming
+    the final state is durable even if the process exits immediately after.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    rm.finalise_run_metadata(meta_file, run_meta, exit_status="success")
+
+    assert "end_time" in run_meta
+    assert run_meta["exit_status"] == "success"
+    with open(meta_file) as f:
+        on_disk = json.load(f)
+    assert on_disk["exit_status"] == "success"
+
+
+def test_finalise_records_error_message(tmp_path):
+    """finalise_run_metadata stores the exception message when exit_status is 'error'.
+
+    The error string lets someone reading the metadata understand what went
+    wrong without having to dig through log files.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    rm.finalise_run_metadata(meta_file, run_meta, exit_status="error", error="ValueError: bad input")
+
+    assert run_meta["error"] == "ValueError: bad input"
+
+
+def test_finalise_with_psutil(tmp_path):
+    """finalise_run_metadata records memory and CPU usage when psutil is available.
+
+    psutil.Process is mocked to return fixed RSS memory (500 MB) and CPU times
+    (10 s user + 2 s system = 12 s total). We use pytest.approx because the
+    MB conversion involves floating-point division. _PSUTIL_AVAILABLE is patched
+    to True so the resource block is entered regardless of whether psutil is
+    actually installed in the test environment.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    mock_proc = MagicMock()
+    mock_proc.memory_info.return_value.rss = 500_000_000   # bytes -> 500 MB
+    mock_proc.cpu_times.return_value = (10.0, 2.0, 0.0, 0.0)  # user, system, ...
+
+    with patch("autoprot.utils.metadata_recording._PSUTIL_AVAILABLE", True), \
+         patch("autoprot.utils.metadata_recording.psutil.Process", return_value=mock_proc):
+        rm.finalise_run_metadata(meta_file, run_meta)
+
+    assert run_meta["resources"]["peak_memory_mb"] == pytest.approx(500.0)
+    assert run_meta["resources"]["cpu_time_s"] == pytest.approx(12.0)
+
+
+def test_finalise_without_psutil(tmp_path):
+    """finalise_run_metadata omits the resources key when psutil is not installed.
+
+    psutil is an optional dependency. If absent, finalise should complete
+    normally and simply not record resource usage — downstream code reading
+    the metadata must handle the missing key gracefully.
+    """
+    meta_file = str(tmp_path / "run_metadata.json")
+    run_meta = {"steps": []}
+
+    with patch("autoprot.utils.metadata_recording._PSUTIL_AVAILABLE", False):
+        rm.finalise_run_metadata(meta_file, run_meta)
+
+    assert "resources" not in run_meta

--- a/tests/test_metadata_recording.py
+++ b/tests/test_metadata_recording.py
@@ -27,6 +27,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 import autoprot.utils.metadata_recording as rm
 
@@ -223,19 +224,22 @@ def _mock_git_info(**kwargs):
 @patch("autoprot.utils.metadata_recording.get_conda_env", return_value="numpy 1.26\n")
 @patch("autoprot.utils.metadata_recording.get_git_info", return_value=_mock_git_info())
 def test_log_run_metadata_creates_file(mock_git, mock_conda, tmp_path):
-    """log_run_metadata writes a valid JSON file containing all expected keys.
+    """log_run_metadata writes a valid YAML file with the expected schema.
 
     git and conda calls are mocked so the test does not require a real repo
     or conda installation. We verify that:
-      - the file is created on disk and is valid JSON
+      - the YAML file is created on disk under <meta_dir>/run_metadata.yaml
+      - top-level keys follow the schema: run, steps, config, provenance
       - input file hashes, config, git info, and platform are all present
       - steps is initialised as an empty list (no steps have run yet)
-      - start_time is recorded
+      - start_time is recorded under run.start_time
+      - conda env dump is written to conda_envs/<env_name>.txt
     """
     input_file = tmp_path / "input.txt"
     input_file.write_bytes(b"data")
     out_path = str(tmp_path)
-    meta_file = str(tmp_path / "run_metadata.json")
+    meta_dir = tmp_path / "run_metadata"
+    meta_file = str(meta_dir / "run_metadata.yaml")
 
     result_file, result_meta = rm.log_run_metadata(
         input_files=[str(input_file)],
@@ -247,14 +251,17 @@ def test_log_run_metadata_creates_file(mock_git, mock_conda, tmp_path):
 
     assert os.path.exists(result_file)
     with open(result_file) as f:
-        on_disk = json.load(f)
+        on_disk = yaml.safe_load(f)
 
-    assert on_disk["git"]["commit"] == GOOD_COMMIT
+    assert on_disk["provenance"]["git"]["commit"] == GOOD_COMMIT
     assert on_disk["config"] == {"threshold": 0.05}
-    assert str(input_file) in on_disk["input_files"]
+    # no repo_root provided, so input_files uses absolute paths as keys
+    assert str(input_file) in on_disk["provenance"]["input_files"]
     assert on_disk["steps"] == []
-    assert "start_time" in on_disk
-    assert "platform" in on_disk
+    assert "start_time" in on_disk["run"]
+    assert "platform" in on_disk["provenance"]
+    # conda env text is written to a separate file, not inlined
+    assert os.path.exists(str(meta_dir / "conda_envs" / "auto-proteomics.txt"))
 
 
 # ---------------------------------------------------------------------------
@@ -309,13 +316,13 @@ def test_load_run_metadata_no_steps(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_record_step_complete_appends_and_flushes(tmp_path):
-    """record_step_complete appends each step and keeps the JSON file in sync.
+    """record_step_complete appends each step and keeps the YAML file in sync.
 
     We call it twice and verify that both the in-memory dict and the on-disk
-    JSON reflect both entries. The flush-to-disk behaviour is critical: if
+    YAML reflect both entries. The flush-to-disk behaviour is critical: if
     the run is interrupted after this call, the completed step is not lost.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
+    meta_file = str(tmp_path / "run_metadata.yaml")
     run_meta = {"steps": []}
 
     rm.record_step_complete("data_processing", "success", run_meta, meta_file)
@@ -323,7 +330,7 @@ def test_record_step_complete_appends_and_flushes(tmp_path):
 
     assert len(run_meta["steps"]) == 2
     with open(meta_file) as f:
-        on_disk = json.load(f)
+        on_disk = yaml.safe_load(f)
     assert len(on_disk["steps"]) == 2
     assert on_disk["steps"][0]["step"] == "data_processing"
 
@@ -334,7 +341,7 @@ def test_record_step_complete_with_details(tmp_path):
     The details argument lets callers attach step-specific metadata (e.g.
     number of proteins quantified). We confirm the dict is preserved verbatim.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
+    meta_file = str(tmp_path / "run_metadata.yaml")
     run_meta = {"steps": []}
 
     rm.record_step_complete(
@@ -351,7 +358,7 @@ def test_record_step_complete_error_status(tmp_path):
     Failed steps must be recorded (not silently dropped) so that resume
     logic can identify which steps need to be re-run.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
+    meta_file = str(tmp_path / "run_metadata.yaml")
     run_meta = {"steps": []}
 
     rm.record_step_complete("normalisation", "error", run_meta, meta_file)
@@ -364,21 +371,22 @@ def test_record_step_complete_error_status(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_finalise_adds_end_time_and_status(tmp_path):
-    """finalise_run_metadata adds end_time and exit_status and flushes to disk.
+    """finalise_run_metadata adds end_time and exit_status inside run_meta['run'].
 
-    Both the in-memory dict and the JSON file on disk are checked, confirming
+    Both the in-memory dict and the YAML file on disk are checked, confirming
     the final state is durable even if the process exits immediately after.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
-    run_meta = {"steps": []}
+    meta_file = str(tmp_path / "run_metadata.yaml")
+    run_meta = {"run": {"start_time": "2024-01-01T00:00:00+00:00"}, "steps": []}
 
     rm.finalise_run_metadata(meta_file, run_meta, exit_status="success")
 
-    assert "end_time" in run_meta
-    assert run_meta["exit_status"] == "success"
+    assert "end_time" in run_meta["run"]
+    assert run_meta["run"]["exit_status"] == "success"
+    assert run_meta["run"]["duration_s"] is not None
     with open(meta_file) as f:
-        on_disk = json.load(f)
-    assert on_disk["exit_status"] == "success"
+        on_disk = yaml.safe_load(f)
+    assert on_disk["run"]["exit_status"] == "success"
 
 
 def test_finalise_records_error_message(tmp_path):
@@ -387,16 +395,16 @@ def test_finalise_records_error_message(tmp_path):
     The error string lets someone reading the metadata understand what went
     wrong without having to dig through log files.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
-    run_meta = {"steps": []}
+    meta_file = str(tmp_path / "run_metadata.yaml")
+    run_meta = {"run": {"start_time": "2024-01-01T00:00:00+00:00"}, "steps": []}
 
     rm.finalise_run_metadata(meta_file, run_meta, exit_status="error", error="ValueError: bad input")
 
-    assert run_meta["error"] == "ValueError: bad input"
+    assert run_meta["run"]["error"] == "ValueError: bad input"
 
 
 def test_finalise_with_psutil(tmp_path):
-    """finalise_run_metadata records memory and CPU usage when psutil is available.
+    """finalise_run_metadata records memory and CPU usage inside run_meta['run'].
 
     psutil.Process is mocked to return fixed RSS memory (500 MB) and CPU times
     (10 s user + 2 s system = 12 s total). We use pytest.approx because the
@@ -404,8 +412,8 @@ def test_finalise_with_psutil(tmp_path):
     to True so the resource block is entered regardless of whether psutil is
     actually installed in the test environment.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
-    run_meta = {"steps": []}
+    meta_file = str(tmp_path / "run_metadata.yaml")
+    run_meta = {"run": {"start_time": "2024-01-01T00:00:00+00:00"}, "steps": []}
 
     mock_proc = MagicMock()
     mock_proc.memory_info.return_value.rss = 500_000_000   # bytes -> 500 MB
@@ -415,8 +423,8 @@ def test_finalise_with_psutil(tmp_path):
          patch("autoprot.utils.metadata_recording.psutil.Process", return_value=mock_proc):
         rm.finalise_run_metadata(meta_file, run_meta)
 
-    assert run_meta["resources"]["peak_memory_mb"] == pytest.approx(500.0)
-    assert run_meta["resources"]["cpu_time_s"] == pytest.approx(12.0)
+    assert run_meta["run"]["resources"]["peak_memory_mb"] == pytest.approx(500.0)
+    assert run_meta["run"]["resources"]["cpu_time_s"] == pytest.approx(12.0)
 
 
 def test_finalise_without_psutil(tmp_path):
@@ -426,10 +434,10 @@ def test_finalise_without_psutil(tmp_path):
     normally and simply not record resource usage — downstream code reading
     the metadata must handle the missing key gracefully.
     """
-    meta_file = str(tmp_path / "run_metadata.json")
-    run_meta = {"steps": []}
+    meta_file = str(tmp_path / "run_metadata.yaml")
+    run_meta = {"run": {"start_time": "2024-01-01T00:00:00+00:00"}, "steps": []}
 
     with patch("autoprot.utils.metadata_recording._PSUTIL_AVAILABLE", False):
         rm.finalise_run_metadata(meta_file, run_meta)
 
-    assert "resources" not in run_meta
+    assert "resources" not in run_meta["run"]


### PR DESCRIPTION
added metadata recording. When main.py is run, lots of metadata is sent to an output/run_metadata/run_metadata.yaml, making the whole thing reproducible. Exactly which data, code (git hash + git diff) and config was used.

new setting process_prot_data allows control about whether to process prot data - saves time if that has already been done